### PR TITLE
build: update go.mod to fix go build bug under MacOS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,17 +5,16 @@ go 1.18
 require (
 	github.com/Akegarasu/blivedm-go v1.3.0
 	github.com/gorilla/handlers v1.5.1
+	github.com/gorilla/websocket v1.4.2
 
 )
 
 require (
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect
-	github.com/google/uuid v1.3.0 // indirect
-	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/tidwall/gjson v1.13.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
-	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
+	golang.org/x/sys v0.10.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
-github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
 github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
@@ -24,5 +22,6 @@ github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
+golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
```
go run main.go
# golang.org/x/sys/unix
../go/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/syscall_darwin.1_13.go:25:3: //go:linkname must refer to declared function or variable
../go/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.1_13.go:27:3: //go:linkname must refer to declared function or variable
../go/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.1_13.go:40:3: //go:linkname must refer to declared function or variable
../go/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.go:28:3: //go:linkname must refer to declared function or variable
../go/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.go:43:3: //go:linkname must refer to declared function or variable
../go/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.go:59:3: //go:linkname must refer to declared function or variable
../go/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.go:75:3: //go:linkname must refer to declared function or variable
../go/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.go:90:3: //go:linkname must refer to declared function or variable
../go/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.go:105:3: //go:linkname must refer to declared function or variable
../go/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.go:121:3: //go:linkname must refer to declared function or variable
../go/pkg/mod/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037/unix/zsyscall_darwin_arm64.go:121:3: too many errors
```

在 MacOS（apple silicon)  下面运行会报错，试了重装 golang ，每次重装 go 都能触发这个问题。在我当前的平台下，这个 `x/sys` 的库应该是过时了。

 `go get -u golang.org/x/sys` 手动更新下就好了。

我也已经更新了依赖项，没有做其他更改。

祝 Merlin 少掉小珍珠~