### PR TITLE
feat: update blivedm

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module BliveMusicBoard
 go 1.18
 
 require (
-	github.com/Akegarasu/blivedm-go v1.3.0
+	github.com/Akegarasu/blivedm-go v1.3.1
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/websocket v1.4.2
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Akegarasu/blivedm-go v1.3.0 h1:PYnF4DP/FnkyElpBq+Q594N9rTmPZ0GdCgQkGRT4wvw=
 github.com/Akegarasu/blivedm-go v1.3.0/go.mod h1:jgljFT4+aXeNDc/fHo7HbkE/SeQZQC5vi5ITWuhmXrM=
+github.com/Akegarasu/blivedm-go v1.3.1 h1:llIN6P1mLcUPhjrR1s52OxykO1onAupfhZMvQfc0SDA=
+github.com/Akegarasu/blivedm-go v1.3.1/go.mod h1:RFptWbxb1pd3txqbIPAcGxZGsSQ+qO9wmHQQzJaGPRg=
 github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY3JY=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -23,5 +25,6 @@ github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JT
 github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
 golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func main() {
 	log.Printf("后台管理界面 http://localhost:%s/admin \n", PORT)
 	log.Println("关注芋艿谢谢喵~ https://live.bilibili.com/326763")
 	//初始化弹幕监听
-	go pkg.SetDanmaku(pkg.GSetting.RoomId.Val.(string))
+	go pkg.SetDanmaku(pkg.GSetting.RoomId.Val.(string), "1")
 
 	// 使用 log 包启动服务器，如果启动失败，程序会直接退出
 	go log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", PORT), handler))

--- a/pkg/danmaku.go
+++ b/pkg/danmaku.go
@@ -2,17 +2,18 @@ package pkg
 
 import (
 	"fmt"
-	"github.com/Akegarasu/blivedm-go/client"
-	"github.com/Akegarasu/blivedm-go/message"
 	"log"
 	"regexp"
 	"time"
+
+	"github.com/Akegarasu/blivedm-go/client"
+	"github.com/Akegarasu/blivedm-go/message"
 )
 
 var c *client.Client
 
-func SetDanmaku(RoomId string) {
-	c = client.NewClient(RoomId) //关注芋艿谢谢喵
+func SetDanmaku(RoomId string, UId string) {
+	c = client.NewClient(RoomId, UId) //关注芋艿谢谢喵
 	c.OnDanmaku(handleSongRequest)
 
 	err := c.Start()

--- a/pkg/setting.go
+++ b/pkg/setting.go
@@ -69,7 +69,7 @@ func SaveSetting() {
 
 	if GSetting.RoomId.Val.(string) != RoomIdCache { //重置弹幕监听
 		RoomIdCache = GSetting.RoomId.Val.(string)
-		go SetDanmaku(GSetting.RoomId.Val.(string))
+		go SetDanmaku(GSetting.RoomId.Val.(string), "1")
 	}
 
 }


### PR DESCRIPTION
> 哇~这是 Merlin 的仓库 （C言C语）

`blivedm-go` 这个库最近也升级了。需要传入一个 uid 来防止触发阿 B 的弹幕身份信息的[打码](https://github.com/simon300000/bilibili-live-ws/issues/397)。

不过好像对于点歌板的使用场景没什么影响。不过如果未来要做“点歌榜”之类的有关用户信息的功能，还是升级一下好。

另外代码里的 uid 默认传了 1 ，如果需要更加规范的话，应该传直播间所属 UP 的 uid。可以在前端设置房间号的页面，新增一个输入框设置 uid 。不过这个功能我还没有做，前端代码还没看。